### PR TITLE
Initial conditions evaluators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: run tests
           command: |
             . .venv/bin/activate
-            tox -e py36,docs
+            tox -e py36,docs -r
 
       - save_cache:
           paths:

--- a/example_data/iec_spec.json
+++ b/example_data/iec_spec.json
@@ -24,6 +24,10 @@
     "FinePitch": 0.0,
     "FeatherPitch": 90.0,
     "IdlingPitch": 90.0,
+    "RatedRotorSpeed": 11.753,
+    "WindSpeedOfRatedRotorSpeed": 9.4,
+    "RatedWindSpeed": 10.0,
+    "InitialPitchCoefficient": 6.45,
     "Startup": {
       "initial_pitch": "$FeatherPitch",
       "final_pitch": "$FinePitch",
@@ -47,13 +51,17 @@
         "wind_speed": "$WindRangeOperating",
         "turbulence_intensity": "#NTM($Iref, !wind_speed)",
         "turbulence_seed": "#repeat(@TurbulenceSeed, 6)",
-        "initial_yaw": "$YawRange"
+        "initial_yaw": "$YawRange",
+        "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+        "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)"
       },
       "dlc2.4": {
         "policy:path": "dlc2.4/WS_{wind_speed}/yaw{initial_yaw:1}",
         "simulation_time": 600,
         "wind_speed": "$WindRangeOperating",
         "initial_yaw": [-20, 20],
+        "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+        "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)",
         "turbulence_intensity": "#NTM($Iref, !wind_speed)",
         "turbulence_seed": "#repeat(@TurbulenceSeed, 3)"
       },
@@ -106,6 +114,8 @@
           "wind_speed": "$WindRangeOperating",
           "turbulence_seed": "#repeat(@TurbulenceSeed, 6)",
           "initial_yaw": "$YawRange",
+          "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+          "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)",
           "dlc1.1": {
             "policy:path": "dlc1.1/WS_{wind_speed}/yaw{initial_yaw:1}",
             "turbulence_intensity": "#NTM($Iref, !wind_speed)"
@@ -147,6 +157,8 @@
           "policy:path": "dlc2.1/WS_{wind_speed}/yaw{initial_yaw:1}",
           "wind_speed": "$WindRangeOperating",
           "initial_yaw": "$YawRange",
+          "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+          "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)",
           "grid_loss_time": 40.0,
           "turbulence_seed": "#repeat(@TurbulenceSeed, 4)",
           "_safety_factor": "$Normal"
@@ -155,6 +167,8 @@
           "policy:path": "dlc2.2/runaway/WS_{wind_speed}",
           "simulation_time": 100,
           "wind_speed": "#range(12, 24, 2)",
+          "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+          "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)",
           "turbulence_seed": "#repeat(@TurbulenceSeed, 12)",
           "blade_pitch_manoeuvre_time[1]": 40.0,
           "pitch_manoeuvre_rate": 8.0,
@@ -167,12 +181,16 @@
           "wind_speed": "$WindRangeOperating",
           "turbulence_seed": "@TurbulenceSeed",
           "initial_yaw": "$YawRange360",
+          "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+          "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)",
           "_safety_factor": "$Abnormal"
         },
         "dlc2.2b": {
           "policy:path": "dlc2.2/stuck/WS_{wind_speed}",
           "simulation_time": 600,
           "wind_speed": "$WindRangeOperating",
+          "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+          "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)",
           "turbulence_seed": "#repeat(@TurbulenceSeed, 12)",
           "blade_initial_pitch[1]": "$FinePitch",
           "_safety_factor": "$Abnormal"
@@ -243,6 +261,8 @@
         "wind_speed": ["$Vrated_m2", "$Vrated_p2", "$Vout"],
         "turbulence_intensity": "#NTM($Iref, !wind_speed)",
         "turbulence_seed": "#repeat(@TurbulenceSeed, 12)",
+        "initial_rotor_speed": "#ApproxInitialRotorSpeed($RatedRotorSpeed, $WindSpeedOfRatedRotorSpeed, !wind_speed)",
+        "initial_pitch": "#ApproxInitialPitch($RatedWindSpeed, $FinePitch, $InitialPitchCoefficient, !wind_speed)",
         "_safety_factor": "$Normal"
       },
       "dlc6": {

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(_here, 'README.md')) as fp:
     README_CONTENTS = fp.read()
 
 install_requires = [
-    'spawn==0.1.9',
+    'spawn==0.3.0',
     'wetb==0.0.9',
     'setuptools>=38.3'
 ]

--- a/spawnwind/nrel/plugin.py
+++ b/spawnwind/nrel/plugin.py
@@ -104,7 +104,7 @@ def ETM(Iref, Vmean, wind_speed):
 
 
 #pylint: disable=invalid-name
-def InitialRotorSpeed(rated_rotor_speed, rated_wind_speed, wind_speed):
+def ApproxInitialRotorSpeed(rated_rotor_speed, rated_wind_speed, wind_speed):
     """
     Additional evaluator - approximately evaluates initial rotor speed
     :param rated_rotor_speed: Maximum operational rotor speed

--- a/spawnwind/nrel/plugin.py
+++ b/spawnwind/nrel/plugin.py
@@ -17,6 +17,7 @@
 """Defines the :mod:`mutliwindcalc` plugin for nrel
 """
 from os import path
+from math import sqrt
 
 from luigi import configuration
 
@@ -100,3 +101,33 @@ def ETM(Iref, Vmean, wind_speed):
     #pylint: disable=invalid-name
     c = 2.0
     return c * Iref * (0.072 * (Vmean / c + 3.0) * (wind_speed / c - 4) + 10.0) / wind_speed
+
+
+#pylint: disable=invalid-name
+def InitialRotorSpeed(rated_rotor_speed, rated_wind_speed, wind_speed):
+    """
+    Additional evaluator - approximately evaluates initial rotor speed
+    :param rated_rotor_speed: Maximum operational rotor speed
+    :param rated_wind_speed: Wind speed at which maximum rotor speed is reached
+    :param wind_speed: Mean wind speed of run at which to calculate initial rotor speed
+    :return: Approximate initial rotor speed for run
+    """
+    return min(rated_wind_speed, wind_speed) * rated_rotor_speed / rated_wind_speed
+
+
+#pylint: disable=invalid-name
+def ApproxInitialPitch(rated_wind_speed, fine_pitch_angle, coefficient, wind_speed):
+    """
+    Additional evaluator - approximately evaluates initial pitch angle in degrees according to (above rated):
+    pitch_angle = fine_pitch_angle + coefficient * sqrt(wind_speed - rated_wind_speed)
+    :param rated_wind_speed: Wind speed at which turbine starts to pitch above fine pitch
+    :param fine_pitch_angle: Pitch angle below rated
+    :param coefficient: Coefficient of increase in pitch angle above rated wind speed
+    :param wind_speed: (mean) Wind speed at which to evaluate initial pitch angle
+    :return: fine_pitch_angle if wind_speed <= rated_wind_speed
+    else fine_pitch_angle + coefficient * sqrt(wind_speed - rated_wind_speed)
+    """
+    if wind_speed <= rated_wind_speed:
+        return fine_pitch_angle
+    else:
+        return fine_pitch_angle + coefficient * sqrt(wind_speed - rated_wind_speed)

--- a/spawnwind/nrel/turbsim_spawner.py
+++ b/spawnwind/nrel/turbsim_spawner.py
@@ -29,13 +29,13 @@ class TurbsimSpawner(WindGenerationSpawner):
     def __init__(self, turbsim_input):
         self._input = turbsim_input
 
-    def spawn(self, path, metadata):
-        wind_input_file = os_path.join(path, 'wind.ipt')
+    def spawn(self, path_, metadata):
+        wind_input_file = os_path.join(path_, 'wind.ipt')
         if not os_path.isdir(os_path.dirname(wind_input_file)):
             makedirs(os_path.dirname(wind_input_file))
         self._input.to_file(wind_input_file)
         extension = '.wnd' if self.wind_type == 'bladed' else '.bts'
-        wind_task = WindGenerationTask('wind ' + path,
+        wind_task = WindGenerationTask('wind ' + path_,
                                        _input_file_path=wind_input_file,
                                        _metadata=metadata,
                                        _extension=extension)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -26,6 +26,8 @@ def test_successfully_inspects_iec_spec(example_data_folder):
     with open(input_path) as fp:
         spec = json.load(fp)
 
+    stats = spawn.stats(spec, {'format': 'json'})
+    assert stats['leaf_count'] == 1591
     inspection = spawn.inspect(spec, {'format': 'json'})
     assert isinstance(inspection, dict)
     assert 'spec' in inspection

--- a/tests/nrel/evaluator_tests.py
+++ b/tests/nrel/evaluator_tests.py
@@ -1,0 +1,36 @@
+import pytest
+from spawnwind.nrel.plugin import NTM, ETM, ApproxInitialPitch, ApproxInitialRotorSpeed
+
+
+@pytest.mark.parametrize('Iref,wind_speed', [
+    (12.0, 2.0),
+    (12.0, 11.0),
+    (16.0, 7.0),
+    (16.0, 9.0),
+])
+def test_extreme_model_has_higher_turbulence_than_normal_model(Iref, wind_speed):
+    assert ETM(Iref, 8.0, wind_speed) > NTM(Iref, wind_speed)
+
+
+def test_turbulence_models_have_lower_turbulence_at_higher_wind_speeds():
+    assert NTM(14.0, 10.0) < NTM(14.0, 5.0)
+    assert ETM(14.0, 7.5, 10.0) < ETM(14.0, 7.5, 5.0)
+
+
+def test_initial_rotor_speed():
+    omega_rated = 8.0
+    ws_rated = 9.0
+    assert ApproxInitialRotorSpeed(omega_rated, ws_rated, 0.0) == 0.0
+    assert ApproxInitialRotorSpeed(omega_rated, ws_rated, ws_rated/2) == pytest.approx(omega_rated / 2)
+    assert ApproxInitialRotorSpeed(omega_rated, ws_rated, ws_rated) == pytest.approx(omega_rated)
+    assert ApproxInitialRotorSpeed(omega_rated, ws_rated, 2 * ws_rated) == omega_rated
+
+
+def test_initial_pitch():
+    omega_rated = 8.0
+    ws_rated = 11.0
+    fine_pitch = 0.0
+    coeff = 6.0
+    assert ApproxInitialPitch(ws_rated, fine_pitch, coeff, ws_rated/2) == 0.0
+    assert ApproxInitialPitch(ws_rated, fine_pitch, coeff, ws_rated) == pytest.approx(0.0)
+    assert 0.0 < ApproxInitialPitch(ws_rated, fine_pitch, coeff, 2 * ws_rated) < 90.0

--- a/tests/nrel/fast_spawner_tests.py
+++ b/tests/nrel/fast_spawner_tests.py
@@ -112,3 +112,17 @@ def test_properties_of_spawner_sub_modules_are_independent_on_branches(turbsim_i
     spawner.initial_rotor_speed = 8.0
     branch.initial_rotor_speed = 9.0
     assert spawner.initial_rotor_speed != branch.initial_rotor_speed
+
+@pytest.mark.skipif('sys.platform != "win32"')
+def test_fails_with_invalid_parameter(turbsim_input, fast_input, tmpdir, plugin_loader):
+    spawner = FastSimulationSpawner(fast_input, TurbsimSpawner(turbsim_input), tmpdir)
+    spec_dict = {
+        "spec": {
+            "simulation_time": 1.0,
+            "yaw_angle": 10.0
+        }
+    }
+    spec = SpecificationParser(plugin_loader).parse(spec_dict)
+    config = CommandLineConfiguration(workers=2, runner_type='process', prereq_outdir='prerequisites', outdir=tmpdir, local=True)
+    scheduler = LuigiScheduler(config)
+    scheduler.run(spawner, spec)


### PR DESCRIPTION
Added two evaluators which are useful for improving initial conditions for FAST runs:
* `ApproxInitialRotorSpeed` - simple linear ramp from zero rotor speed at zero wind speed to rated rotor speed at rated wind speed
* `ApproxInitialPitch` - initial pitch angle approximated as `fine pitch angle + coefficient * sqrt(wind speed - rated wind speed)`